### PR TITLE
Dependency update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "1.3.72"
+    id "org.jetbrains.kotlin.jvm" version "1.4.30"
 }
 
 ext {

--- a/plugin-bazel-agent/build.gradle
+++ b/plugin-bazel-agent/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id 'com.github.rodm.teamcity-agent' version "1.0"
+  id 'com.github.rodm.teamcity-agent' version '1.4.1'
 }
 
 teamcity {

--- a/plugin-bazel-agent/build.gradle
+++ b/plugin-bazel-agent/build.gradle
@@ -40,7 +40,7 @@ dependencies {
   compile "com.fasterxml.jackson.module:jackson-module-kotlin:2.10.0"
   provided "org.jetbrains.teamcity.internal:agent:${teamcityVersion}"
   provided "org.jetbrains.teamcity:common-api:${teamcityVersion}"
-  implementation project(':plugin-bazel-event-service')
+  compileOnly project(':plugin-bazel-event-service')
   testCompile 'org.testng:testng:6.8'
   testCompile 'org.jmock:jmock:2.5.1'
   testCompile 'io.mockk:mockk:1.11.0'

--- a/plugin-bazel-common/build.gradle
+++ b/plugin-bazel-common/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins{
-    id 'com.github.rodm.teamcity-common' version '1.0'
+    id 'com.github.rodm.teamcity-common' version '1.4.1'
 }
 
 dependencies {

--- a/plugin-bazel-event-service/build.gradle
+++ b/plugin-bazel-event-service/build.gradle
@@ -15,7 +15,7 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.4.30'
 
     repositories {
         mavenCentral()

--- a/plugin-bazel-server/build.gradle
+++ b/plugin-bazel-server/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    id 'com.github.rodm.teamcity-server' version "1.0"
+    id 'com.github.rodm.teamcity-server' version '1.4.1'
 }
 
 teamcity {
@@ -23,6 +23,7 @@ teamcity {
 
     server {
         descriptor = project.file('teamcity-plugin.xml')
+        archiveName = 'teamcity-bazel-plugin'
         tokens = [Plugin_Version: project.version]
         files {
             into('kotlin-dsl') {

--- a/plugin-bazel-server/src/main/kotlin/jetbrains/buildServer/bazel/BazelBuildFeature.kt
+++ b/plugin-bazel-server/src/main/kotlin/jetbrains/buildServer/bazel/BazelBuildFeature.kt
@@ -20,7 +20,6 @@ import jetbrains.buildServer.serverSide.BuildFeature
 import jetbrains.buildServer.serverSide.InvalidProperty
 import jetbrains.buildServer.serverSide.PropertiesProcessor
 import jetbrains.buildServer.web.openapi.PluginDescriptor
-import kotlin.coroutines.experimental.buildSequence
 import java.net.MalformedURLException
 import java.net.URL
 

--- a/plugin-bazel-server/src/main/kotlin/jetbrains/buildServer/bazel/BazelRunnerDiscoveryExtension.kt
+++ b/plugin-bazel-server/src/main/kotlin/jetbrains/buildServer/bazel/BazelRunnerDiscoveryExtension.kt
@@ -21,7 +21,6 @@ import jetbrains.buildServer.serverSide.discovery.BuildRunnerDiscoveryExtension
 import jetbrains.buildServer.serverSide.discovery.DiscoveredObject
 import jetbrains.buildServer.util.browser.Browser
 import jetbrains.buildServer.util.browser.Element
-import kotlin.coroutines.experimental.buildSequence
 
 /**
  * Performs bazel build steps discovery.

--- a/plugin-bazel-server/src/main/kotlin/jetbrains/buildServer/bazel/fetchers/BazelFileParser.kt
+++ b/plugin-bazel-server/src/main/kotlin/jetbrains/buildServer/bazel/fetchers/BazelFileParser.kt
@@ -23,7 +23,6 @@ import org.antlr.v4.runtime.tree.ParseTreeWalker
 import org.jetbrains.bazel.BazelBuildFileLexer
 import org.jetbrains.bazel.BazelBuildFileParser
 import java.io.InputStream
-import kotlin.coroutines.experimental.buildSequence
 
 object BazelFileParser {
 

--- a/plugin-bazel-server/src/main/kotlin/jetbrains/buildServer/bazel/fetchers/BazelTargetFetcher.kt
+++ b/plugin-bazel-server/src/main/kotlin/jetbrains/buildServer/bazel/fetchers/BazelTargetFetcher.kt
@@ -21,7 +21,6 @@ import jetbrains.buildServer.serverSide.DataItem
 import jetbrains.buildServer.serverSide.ProjectDataFetcher
 import jetbrains.buildServer.util.browser.Browser
 import jetbrains.buildServer.util.browser.Element
-import kotlin.coroutines.experimental.buildSequence
 
 /**
  * Provides the list of targets in directory.


### PR DESCRIPTION
The newer versions of gradle-teamcity-plugin provide convenient [tasks](https://github.com/rodm/gradle-teamcity-plugin/blob/v1.4/README.adoc#tasks-2) for setting up a TeamCity server and agent for manual testing.

After the update, the plugin seems to work correctly.