### PR TITLE
Fix MainKtTest on buildserver

### DIFF
--- a/plugin-bazel-agent/src/main/kotlin/jetbrains/buildServer/bazel/BesCommandLineBuilder.kt
+++ b/plugin-bazel-agent/src/main/kotlin/jetbrains/buildServer/bazel/BesCommandLineBuilder.kt
@@ -3,7 +3,6 @@
 package jetbrains.buildServer.bazel
 
 import jetbrains.buildServer.RunBuildException
-import jetbrains.buildServer.agent.FileSystemService
 import jetbrains.buildServer.agent.runner.*
 import jetbrains.buildServer.bazel.BazelConstants.PARAM_INTEGRATION_MODE
 import jetbrains.buildServer.runner.JavaRunnerConstants
@@ -18,9 +17,9 @@ class BesCommandLineBuilder(
     : CommandLineBuilder {
     override fun build(command: BazelCommand): ProgramCommandLine {
         val sb = StringBuilder()
-        sb.appendln(_pathsService.toolPath)
+        sb.appendLine(_pathsService.toolPath)
         for (arg in _argumentsConverter.convert(getArgs(command))) {
-            sb.appendln(StringUtil.unquoteString(arg))
+            sb.appendLine(StringUtil.unquoteString(arg))
         }
 
         val bazelCommandFile = File(_pathsService.getPath(PathType.AgentTemp), _pathsService.uniqueName)

--- a/plugin-bazel-event-service/build.gradle
+++ b/plugin-bazel-event-service/build.gradle
@@ -28,13 +28,13 @@ repositories {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.18.0' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.60.1' // CURRENT_GRPC_VERSION
 
 dependencies {
     compile project(':rx')
     compile "commons-cli:commons-cli:1.4"
     compile "org.jetbrains.kotlin:kotlin-stdlib"
-    compile "com.google.api.grpc:proto-google-common-protos:1.17.0"
+    compile "com.google.api.grpc:proto-google-common-protos:2.30.0"
     compile "io.grpc:grpc-netty:${grpcVersion}"
     compile "io.grpc:grpc-protobuf:${grpcVersion}"
     compile "io.grpc:grpc-stub:${grpcVersion}"
@@ -58,7 +58,7 @@ sourceSets {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.6.1' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.25.2' }
     plugins {
         grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
     }

--- a/plugin-bazel-event-service/src/main/kotlin/bazel/messages/handlers/ActionExecutedHandler.kt
+++ b/plugin-bazel-event-service/src/main/kotlin/bazel/messages/handlers/ActionExecutedHandler.kt
@@ -7,13 +7,10 @@ import bazel.Verbosity
 import bazel.atLeast
 import bazel.bazel.events.ActionExecuted
 import bazel.bazel.events.BazelEvent
-import bazel.bazel.events.File
 import bazel.bazel.events.read
 import bazel.messages.Color
 import bazel.messages.ServiceMessageContext
 import bazel.messages.apply
-import bazel.messages.logError
-import java.io.InputStreamReader
 
 class ActionExecutedHandler : EventHandler {
     override val priority: HandlerPriority
@@ -26,24 +23,24 @@ class ActionExecutedHandler : EventHandler {
                 ctx.hierarchy.createNode(event.id, event.children, actionName)
 
                 val details = StringBuilder()
-                details.appendln(event.cmdLines.joinToStringEscaped().trim())
+                details.appendLine(event.cmdLines.joinToStringEscaped().trim())
 
                 var content = event.primaryOutput.read(ctx)
                 if (content.isNotBlank()) {
-                    details.appendln(content)
+                    details.appendLine(content)
                 }
 
                 content = event.stdout.read(ctx)
                 if (content.isNotBlank()) {
-                    details.appendln(content)
+                    details.appendLine(content)
                 }
 
                 content = event.stderr.read(ctx)
                 if (content.isNotBlank()) {
-                    details.appendln(content.apply(Color.Error))
+                    details.appendLine(content.apply(Color.Error))
                 }
 
-                details.appendln("Exit code: ${event.exitCode}")
+                details.appendLine("Exit code: ${event.exitCode}")
 
                 if (event.success) {
                     if (ctx.verbosity.atLeast(Verbosity.Detailed)) {

--- a/plugin-bazel-event-service/src/test/kotlin/bazel/MainKtTest.kt
+++ b/plugin-bazel-event-service/src/test/kotlin/bazel/MainKtTest.kt
@@ -25,8 +25,7 @@ class MainKtTest {
 
         mockkConstructor(BazelRunner::class)
         every { anyConstructed<BazelRunner>().args } returns sequenceOf("foo", "bar")
-        every { anyConstructed<BazelRunner>().run() } returns
-                BazelRunner.Result(57, listOf("fake error 1", "fake error 2"))
+        every { anyConstructed<BazelRunner>().run() } returns BazelRunner.Result(57, emptyList())
     }
 
     @Test


### PR DESCRIPTION
`shouldSubscribeToBuildEventBinaryFile` is failing on teamcity.jetbrains.com buildserver due to error service message in the stdout

```
Starting: foo bar
in directory: /teamcity-bazel-plugin/plugin-bazel-event-service/.
##teamcity[message tc:tags='tc:parseServiceMessagesInside' text='fake error 1' status='ERROR']
##teamcity[message tc:tags='tc:parseServiceMessagesInside' text='fake error 2' status='ERROR']
next 1
next 2
```
<img width="683" alt="image" src="https://github.com/JetBrains/teamcity-bazel-plugin/assets/9516149/210f22a2-3870-4a23-ac87-4394a4821327">
