### PR TITLE
Do not emit a build problem when there are no tests to run (exit code 4)

### DIFF
--- a/plugin-bazel-agent/src/main/kotlin/jetbrains/buildServer/bazel/BazelRunnerBuildService.kt
+++ b/plugin-bazel-agent/src/main/kotlin/jetbrains/buildServer/bazel/BazelRunnerBuildService.kt
@@ -12,7 +12,6 @@ import jetbrains.buildServer.agent.runner.*
 class BazelRunnerBuildService(
         buildStepContext: BuildStepContext,
         private val _commandRegistry: CommandRegistry,
-        private val _parametersService: ParametersService,
         private val _commandFactory: BazelCommandFactory) : BuildServiceAdapter() {
 
     init {

--- a/plugin-bazel-agent/src/main/kotlin/jetbrains/buildServer/bazel/BazelRunnerBuildService.kt
+++ b/plugin-bazel-agent/src/main/kotlin/jetbrains/buildServer/bazel/BazelRunnerBuildService.kt
@@ -3,9 +3,8 @@
 package jetbrains.buildServer.bazel
 
 import jetbrains.buildServer.RunBuildException
-import jetbrains.buildServer.agent.runner.BuildServiceAdapter
-import jetbrains.buildServer.agent.runner.BuildStepContext
-import jetbrains.buildServer.agent.runner.ProgramCommandLine
+import jetbrains.buildServer.agent.BuildFinishedStatus
+import jetbrains.buildServer.agent.runner.*
 
 /**
  * Bazel runner service.
@@ -13,6 +12,7 @@ import jetbrains.buildServer.agent.runner.ProgramCommandLine
 class BazelRunnerBuildService(
         buildStepContext: BuildStepContext,
         private val _commandRegistry: CommandRegistry,
+        private val _parametersService: ParametersService,
         private val _commandFactory: BazelCommandFactory) : BuildServiceAdapter() {
 
     init {
@@ -20,10 +20,8 @@ class BazelRunnerBuildService(
     }
 
     override fun makeProgramCommandLine(): ProgramCommandLine {
-        val parameters = runnerParameters
-
-        val commandName = parameters[BazelConstants.PARAM_COMMAND]?.trim()
-        if (commandName == null || commandName.isEmpty()) {
+        val commandName = getCommandName()
+        if (commandName.isNullOrEmpty()) {
             val buildException = RunBuildException("Bazel command name is empty")
             buildException.isLogStacktrace = false
             throw buildException
@@ -39,5 +37,22 @@ class BazelRunnerBuildService(
         return command.commandLineBuilder.build(command)
     }
 
+    override fun getRunResult(exitCode: Int): BuildFinishedStatus {
+        if (getCommandName() == "test") {
+            if (exitCode == 3) {
+                return BuildFinishedStatus.FINISHED_SUCCESS
+            } else if (exitCode == 4) {
+                val successWhenNoTests =
+                        runnerParameters[BazelConstants.PARAM_SUCCESS_WHEN_NO_TESTS]?.trim()?.toBoolean()
+                if (successWhenNoTests == true) {
+                    return BuildFinishedStatus.FINISHED_SUCCESS
+                }
+            }
+        }
+        return super.getRunResult(exitCode)
+    }
+
     override fun isCommandLineLoggingEnabled() = false
+
+    private fun getCommandName() = runnerParameters[BazelConstants.PARAM_COMMAND]?.trim()
 }

--- a/plugin-bazel-agent/src/main/kotlin/jetbrains/buildServer/bazel/CommandExecutionAdapter.kt
+++ b/plugin-bazel-agent/src/main/kotlin/jetbrains/buildServer/bazel/CommandExecutionAdapter.kt
@@ -42,17 +42,7 @@ class CommandExecutionAdapter(
             it.processFinished(exitCode)
         }
 
-        if (exitCode == 3) {
-            _processListeners.forEach { it.onStandardOutput("Process finished with exit code $exitCode (some tests have failed). Reporting step success as all the tests have run.") }
-            result = BuildFinishedStatus.FINISHED_SUCCESS
-        }
-        else if (exitCode == 4) {
-            _processListeners.forEach { it.onStandardOutput("Process finished with exit code $exitCode (no tests were found). Reporting step success as there were no test failures.") }
-            result = BuildFinishedStatus.FINISHED_SUCCESS
-        }
-        else {
-            result = _bazelRunnerBuildService.getRunResult(exitCode)
-        }
+        result = _bazelRunnerBuildService.getRunResult(exitCode)
 
         if (result == BuildFinishedStatus.FINISHED_SUCCESS) {
             _bazelRunnerBuildService.afterProcessSuccessfullyFinished()

--- a/plugin-bazel-agent/src/main/kotlin/jetbrains/buildServer/bazel/CommandExecutionAdapter.kt
+++ b/plugin-bazel-agent/src/main/kotlin/jetbrains/buildServer/bazel/CommandExecutionAdapter.kt
@@ -46,6 +46,10 @@ class CommandExecutionAdapter(
             _processListeners.forEach { it.onStandardOutput("Process finished with exit code $exitCode (some tests have failed). Reporting step success as all the tests have run.") }
             result = BuildFinishedStatus.FINISHED_SUCCESS
         }
+        else if (exitCode == 4) {
+            _processListeners.forEach { it.onStandardOutput("Process finished with exit code $exitCode (no tests were found). Reporting step success as there were no test failures.") }
+            result = BuildFinishedStatus.FINISHED_SUCCESS
+        }
         else {
             result = _bazelRunnerBuildService.getRunResult(exitCode)
         }

--- a/plugin-bazel-common/src/main/kotlin/jetbrains/buildServer/bazel/BazelConstants.kt
+++ b/plugin-bazel-common/src/main/kotlin/jetbrains/buildServer/bazel/BazelConstants.kt
@@ -33,6 +33,7 @@ object BazelConstants {
     const val PARAM_WORKING_DIR = AgentRuntimeProperties.BUILD_WORKING_DIR
     const val PARAM_VERBOSITY = "verbosity"
     const val PARAM_INTEGRATION_MODE = "integration"
+    const val PARAM_SUCCESS_WHEN_NO_TESTS = "successWhenNoTests"
 
     // build feature
     const val PARAM_REMOTE_CACHE = "remoteHttpCache"

--- a/plugin-bazel-event-service/src/main/kotlin/bazel/messages/handlers/BuildCompletedHandler.kt
+++ b/plugin-bazel-event-service/src/main/kotlin/bazel/messages/handlers/BuildCompletedHandler.kt
@@ -35,6 +35,13 @@ class BuildCompletedHandler : EventHandler {
                                             .append(", exit code ${event.exitCode}")
                                             .toString()))
                         }
+                        4 -> {
+                            ctx.onNext(ctx.messageFactory.createMessage(
+                                    ctx.buildMessage()
+                                            .append("No tests were found")
+                                            .append(", exit code ${event.exitCode}")
+                                            .toString()))
+                        }
                         else -> {
                             ctx.onNext(ctx.messageFactory.createBuildProblem(
                                     ctx.buildMessage(false)

--- a/plugin-bazel-event-service/src/main/kotlin/bazel/messages/handlers/ProgressHandler.kt
+++ b/plugin-bazel-event-service/src/main/kotlin/bazel/messages/handlers/ProgressHandler.kt
@@ -68,6 +68,7 @@ class ProgressHandler : EventHandler {
 
     companion object {
         private val prefixColors = mapOf<Regex, State>(
+                "^(ERROR:) (No test targets were found, yet testing was requested)".toRegex() to State(Color.Error, false),
                 "^(ERROR:)\\s*(.+)".toRegex() to State(Color.Error, true),
                 "^(FAILED:)\\s*(.+)".toRegex() to State(Color.Error, true),
                 "^(FAIL:)\\s*(.+)".toRegex() to State(Color.Error),

--- a/plugin-bazel-server/src/main/kotlin/jetbrains/buildServer/bazel/BazelParametersProvider.kt
+++ b/plugin-bazel-server/src/main/kotlin/jetbrains/buildServer/bazel/BazelParametersProvider.kt
@@ -34,6 +34,9 @@ class BazelParametersProvider {
     val integrationModeKey: String
         get() = BazelConstants.PARAM_INTEGRATION_MODE
 
+    val successWhenNoTestsKey: String
+        get() = BazelConstants.PARAM_SUCCESS_WHEN_NO_TESTS
+
     val integrationModes: List<IntegrationMode>
         get() = IntegrationMode.values().toList()
 

--- a/plugin-bazel-server/src/main/resources/buildServerResources/editBazelParameters.jsp
+++ b/plugin-bazel-server/src/main/resources/buildServerResources/editBazelParameters.jsp
@@ -149,6 +149,15 @@
 </tr>
 
 <tr class="advancedSetting">
+    <th><label for="${params.successWhenNoTestsKey}">Report success if testing was requested but no tests were found</label></th>
+    <td>
+        <props:checkboxProperty name="${params.successWhenNoTestsKey}" checked="false" className="mediumField">
+        </props:checkboxProperty>
+        <span class="error" id="error_${params.successWhenNoTestsKey}"></span>
+    </td>
+</tr>
+
+<tr class="advancedSetting">
     <th><label for="${params.verbosityKey}">Logging verbosity:</label></th>
     <td>
         <props:selectProperty name="${params.verbosityKey}" enableFilter="true" className="mediumField">

--- a/plugin-bazel-server/src/main/resources/buildServerResources/editBazelParameters.jsp
+++ b/plugin-bazel-server/src/main/resources/buildServerResources/editBazelParameters.jsp
@@ -79,7 +79,7 @@
         Command:<bs:help urlPrefix="https://docs.bazel.build/versions/master/command-line-reference.html#commands" file=""/><l:star/>
     </label></th>
     <td>
-        <props:textProperty name="${params.commandKey}" className="longField"/>
+        <props:textProperty name="${params.commandKey}" className="longField" onchange="BS.toggleDependentElements('test', 'bazel');" onkeyup="BS.toggleDependentElements('test', 'bazel');"/>
         <bs:projectData type="BazelCommands" sourceFieldId="${params.workingDirKey}"
                         targetFieldId="${params.commandKey}" popupTitle="Select command"
                         selectionMode="single" />
@@ -148,7 +148,7 @@
     </td>
 </tr>
 
-<tr class="advancedSetting">
+<tr class="advancedSetting bazel test">
     <th><label for="${params.successWhenNoTestsKey}">Report success if testing was requested but no tests were found</label></th>
     <td>
         <props:checkboxProperty name="${params.successWhenNoTestsKey}" checked="false" className="mediumField">


### PR DESCRIPTION
In a build chain with multiple stages, a test stage sometimes has no tests to run. This can happen if the target pattern file is populated by a Bazel query at the previous stage.

In such cases, Bazel emits a [special exit code](https://bazel.build/run/scripts#exit-codes) which has a very specific meaning and doesn't occur in any other situations. In my opinion, this exit code should not be treated as a build problem.

I know at least one company which uses a shell script to swallow these spurious build problems:
```
bazel test --target_pattern_file=affected_targets
EXIT=$?
[ $EXIT == 4 ] && echo "No targets to test" || exit $EXIT
```

Unfortunately, this precludes them from using the Bazel plugin.

See also https://github.com/bazelbuild/bazel/issues/7291#issuecomment-1283970438.