### PR TITLE
Enable warn-as-error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,14 @@ allprojects {
 subprojects {
     apply plugin: "kotlin"
 
-    compileKotlin { kotlinOptions.jvmTarget = "1.8" }
-    compileTestKotlin { kotlinOptions.jvmTarget = "1.8" }
+    compileKotlin {
+        kotlinOptions.allWarningsAsErrors = true
+        kotlinOptions.jvmTarget = "1.8"
+    }
+    compileTestKotlin {
+        kotlinOptions.allWarningsAsErrors = true
+        kotlinOptions.jvmTarget = "1.8"
+    }
 
     test.useTestNG()
     jar.version = null


### PR DESCRIPTION
So warnings don't get a chance to slip in again.

Builds on #39.