### PR TITLE
Do not turn stderr lines into build problems

### DIFF
--- a/plugin-bazel-event-service/src/main/kotlin/bazel/messages/handlers/ProgressHandler.kt
+++ b/plugin-bazel-event-service/src/main/kotlin/bazel/messages/handlers/ProgressHandler.kt
@@ -28,19 +28,11 @@ class ProgressHandler : EventHandler {
 
                 if (event.stderr.isNotBlank()) {
                     for (errItem in decompose(event.stderr)) {
-                        if (errItem.state.failed) {
-                            ctx.onNext(ctx.messageFactory.createBuildProblem(
-                                    "${errItem.prefix} ${errItem.originalText}",
-                                    ctx.event.projectId,
-                                    ctx.event.payload.content.id.toString()
-                            ))
-                        } else {
-                            ctx.onNext(ctx.messageFactory.createMessage(
-                                    ctx.buildMessage()
-                                            .append(errItem.text)
-                                            .toString()
-                            ))
-                        }
+                        ctx.onNext(ctx.messageFactory.createMessage(
+                                ctx.buildMessage()
+                                        .append(errItem.text)
+                                        .toString()
+                        ))
                     }
                 }
 
@@ -52,36 +44,34 @@ class ProgressHandler : EventHandler {
     }
 
     private fun toMessageItem(text: String): MessageItem {
-        for ((regex, state) in prefixColors) {
+        for ((regex, color) in prefixColors) {
             regex.find(text)?.let {
                 val prefix = it.groupValues[1]
                 val message = it.groupValues[2]
-                return MessageItem("${prefix.apply(state.color)} $message", prefix, message, state)
+                return MessageItem("${prefix.apply(color)} $message", prefix, message, color)
             }
         }
 
-        return MessageItem(text, "", text, State(Color.Default))
+        return MessageItem(text, "", text, Color.Default)
     }
 
-    private data class MessageItem(val text: String, val prefix: String, val originalText: String, val state: State)
-    private data class State(val color: Color, val failed: Boolean = false)
+    private data class MessageItem(val text: String, val prefix: String, val originalText: String, val color: Color)
 
     companion object {
-        private val prefixColors = mapOf<Regex, State>(
-                "^(ERROR:) (No test targets were found, yet testing was requested)".toRegex() to State(Color.Error, false),
-                "^(ERROR:)\\s*(.+)".toRegex() to State(Color.Error, true),
-                "^(FAILED:)\\s*(.+)".toRegex() to State(Color.Error, true),
-                "^(FAIL:)\\s*(.+)".toRegex() to State(Color.Error),
-                "^(Action failed to execute:)\\s*(.+)".toRegex() to State(Color.Error, true),
-                "^(WARNING:)\\s*(.+)".toRegex() to State(Color.Warning),
-                "^(FLAKY:)\\s*(.+)".toRegex() to State(Color.Warning),
-                "^(Auto-Configuration Warning:)\\s*(.+)".toRegex() to State(Color.Warning),
-                "^(DEBUG:)\\s*(.+)".toRegex() to State(Color.Trace),
-                "^(INFO:)\\s*(.+)".toRegex() to State(Color.Success),
-                "^(Analyzing:)\\s*(.+)\$".toRegex() to State(Color.Success),
-                "^(Building:)\\s*(.+)\$".toRegex() to State(Color.Success),
-                "^(\\[\\s*\\d+\\s*\\/\\s*\\d+\\s*\\])\\s*\\[\\s*\\-+\\s*\\]\\s*(.+)\$".toRegex() to State(Color.Success),
-                "^(\\[\\s*\\d+\\s*\\/\\s*\\d+\\s*\\])\\s*(.+)\$".toRegex() to State(Color.Success)
+        private val prefixColors = mapOf(
+                "^(ERROR:)\\s*(.+)".toRegex() to Color.Error,
+                "^(FAILED:)\\s*(.+)".toRegex() to Color.Error,
+                "^(FAIL:)\\s*(.+)".toRegex() to Color.Error,
+                "^(Action failed to execute:)\\s*(.+)".toRegex() to Color.Error,
+                "^(WARNING:)\\s*(.+)".toRegex() to Color.Warning,
+                "^(FLAKY:)\\s*(.+)".toRegex() to Color.Warning,
+                "^(Auto-Configuration Warning:)\\s*(.+)".toRegex() to Color.Warning,
+                "^(DEBUG:)\\s*(.+)".toRegex() to Color.Trace,
+                "^(INFO:)\\s*(.+)".toRegex() to Color.Success,
+                "^(Analyzing:)\\s*(.+)\$".toRegex() to Color.Success,
+                "^(Building:)\\s*(.+)\$".toRegex() to Color.Success,
+                "^(\\[\\s*\\d+\\s*\\/\\s*\\d+\\s*\\])\\s*\\[\\s*\\-+\\s*\\]\\s*(.+)\$".toRegex() to Color.Success,
+                "^(\\[\\s*\\d+\\s*\\/\\s*\\d+\\s*\\])\\s*(.+)\$".toRegex() to Color.Success
         )
     }
 }


### PR DESCRIPTION
The justification for this change is as follows:

- A separate stderr entry doesn't usually correspond to a separate build problem;
- Bazel already has other mechanisms for signalling failure, such as the `actionCompleted` event;
- In case the user _does_ need to detect build problems in the stderr, he can set up a [Failure Condition](https://www.jetbrains.com/help/teamcity/build-failure-conditions.html) (although it will be applied to the whole build rather than a build step).
