### PR TITLE
Allow to configure the maxInboundMessageSize of the BES gRPC server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ plugin-bazel-integration-tests/samples/**/bazel-*
 plugin-bazel-integration-tests/samples/FlakyTests/.idea/
 plugin-bazel-integration-tests/samples/**/.idea
 
+.DS_Store

--- a/plugin-bazel-event-service/src/main/kotlin/bazel/BazelOptions.kt
+++ b/plugin-bazel-event-service/src/main/kotlin/bazel/BazelOptions.kt
@@ -1,5 +1,3 @@
-
-
 package bazel
 
 import org.apache.commons.cli.*
@@ -31,6 +29,8 @@ class BazelOptions(
 
     val bazelCommandlineFile: File? get() = line.getOptionValue("c")?.let { File(it) }
 
+    val maxMessageSizeMb: Int get() = line.getOptionValue("m")?.toInt() ?: 8
+
     companion object {
         private val options = createOptions()
 
@@ -57,6 +57,12 @@ class BazelOptions(
                 "command",
                 true,
                 "Specifies the new line separated file containing bazel executable and its command line arguments.",
+            )
+            options.addOption(
+                "m",
+                "max-message-size",
+                true,
+                "Maximum inbound message size in MB for gRPC server. Optional and 8MB by default.",
             )
             return options
         }

--- a/plugin-bazel-event-service/src/main/kotlin/bazel/Main.kt
+++ b/plugin-bazel-event-service/src/main/kotlin/bazel/Main.kt
@@ -54,7 +54,7 @@ private fun runBesGrpcServerMode(
     messageWriter: MessageWriter,
 ) {
     var finalExitCode = 0
-    val grpcServer = GrpcServer(messageWriter, options.port)
+    val grpcServer = GrpcServer(messageWriter, options.port, options.maxMessageSizeMb)
     val server =
         BesGrpcServer(
             messageWriter,

--- a/plugin-bazel-event-service/src/test/kotlin/bazel/BazelOptionsTest.kt
+++ b/plugin-bazel-event-service/src/test/kotlin/bazel/BazelOptionsTest.kt
@@ -1,0 +1,48 @@
+package bazel
+
+import org.testng.Assert
+import org.testng.annotations.Test
+
+class BazelOptionsTest {
+    @Test
+    fun testDefaultMaxMessageSize() {
+        val options = BazelOptions(arrayOf())
+        Assert.assertEquals(options.maxMessageSizeMb, 8, "Default max message size should be 8MB")
+    }
+
+    @Test
+    fun testCustomMaxMessageSize() {
+        val options = BazelOptions(arrayOf("-m", "16"))
+        Assert.assertEquals(options.maxMessageSizeMb, 16, "Custom max message size should be 16MB")
+    }
+
+    @Test
+    fun testMaxMessageSizeWithLongOption() {
+        val options = BazelOptions(arrayOf("--max-message-size", "16"))
+        Assert.assertEquals(options.maxMessageSizeMb, 16, "Custom max message size should be 16MB")
+    }
+
+    @Test
+    fun testAllOptions() {
+        val options =
+            BazelOptions(
+                arrayOf(
+                    "-l",
+                    "Verbose",
+                    "-p",
+                    "8080",
+                    "-f",
+                    "/tmp/event.bin",
+                    "-c",
+                    "/tmp/bazel.cmd",
+                    "-m",
+                    "16",
+                ),
+            )
+        Assert.assertEquals(options.verbosity, Verbosity.Verbose)
+        Assert.assertEquals(options.port, 8080)
+        Assert.assertEquals(options.eventFile?.toString(), "/tmp/event.bin")
+        Assert.assertEquals(options.bazelCommandlineFile?.path, "/tmp/bazel.cmd")
+        Assert.assertEquals(options.maxMessageSizeMb, 16)
+    }
+}

--- a/plugin-bazel-event-service/src/test/kotlin/bazel/GrpcServerTest.kt
+++ b/plugin-bazel-event-service/src/test/kotlin/bazel/GrpcServerTest.kt
@@ -1,0 +1,277 @@
+package bazel
+
+import bazel.messages.MessageWriter
+import com.google.devtools.build.v1.BuildEvent
+import com.google.devtools.build.v1.OrderedBuildEvent
+import com.google.devtools.build.v1.PublishBuildEventGrpc
+import com.google.devtools.build.v1.PublishBuildToolEventStreamRequest
+import com.google.devtools.build.v1.PublishBuildToolEventStreamResponse
+import com.google.devtools.build.v1.StreamId
+import com.google.protobuf.Any
+import com.google.protobuf.ByteString
+import io.grpc.ManagedChannelBuilder
+import io.grpc.stub.StreamObserver
+import io.mockk.*
+import org.testng.Assert
+import org.testng.annotations.AfterMethod
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class GrpcServerTest {
+    private lateinit var messageWriter: MessageWriter
+    private lateinit var grpcServer: GrpcServer
+    private lateinit var serverCloseable: AutoCloseable
+    private val port = 0 // Use 0 to get a random available port
+
+    @BeforeMethod
+    fun setUp() {
+        messageWriter = mockk(relaxed = true)
+        grpcServer = GrpcServer(messageWriter, port)
+    }
+
+    @AfterMethod
+    fun tearDown() {
+        if (::serverCloseable.isInitialized) {
+            serverCloseable.close()
+        }
+    }
+
+    @Test
+    fun testLargeMessageHandling() {
+        // Create a simple service that captures received events
+        val receivedEvents = mutableListOf<BuildEvent>()
+        val eventLatch = CountDownLatch(1)
+        val responseLatch = CountDownLatch(1)
+
+        val service =
+            BesGrpcServerEventStream(messageWriter) { result ->
+                when (result) {
+                    is BesGrpcServerEventStream.Result.Event -> {
+                        receivedEvents.add(result.event)
+                        eventLatch.countDown()
+                    }
+                    is BesGrpcServerEventStream.Result.Error -> {
+                        Assert.fail("Unexpected error: ${result.throwable}")
+                    }
+                }
+            }
+
+        // Start the server
+        serverCloseable = grpcServer.start(service)
+        val actualPort = grpcServer.port
+        Assert.assertTrue(actualPort > 0, "Server should be started on a valid port")
+
+        // Create a client channel
+        val channel =
+            ManagedChannelBuilder
+                .forAddress("localhost", actualPort)
+                .usePlaintext()
+                .build()
+
+        try {
+            val stub = PublishBuildEventGrpc.newStub(channel)
+
+            // Create a large message (over 4MB)
+            val largeData = ByteString.copyFrom(ByteArray(4 * 1024 * 1024)) // 4MB of data
+            val largeEvent =
+                BuildEvent
+                    .newBuilder()
+                    .setBazelEvent(
+                        Any
+                            .newBuilder()
+                            .setTypeUrl("type.googleapis.com/test.LargeEvent")
+                            .setValue(largeData)
+                            .build(),
+                    ).build()
+
+            val streamId =
+                StreamId
+                    .newBuilder()
+                    .setBuildId("test-build-id")
+                    .build()
+
+            // Send the large message
+            val responseObserver =
+                object : StreamObserver<PublishBuildToolEventStreamResponse> {
+                    override fun onNext(value: PublishBuildToolEventStreamResponse) {
+                        responseLatch.countDown()
+                    }
+
+                    override fun onError(t: Throwable) {
+                        Assert.fail("Client error: ${t.message}")
+                    }
+
+                    override fun onCompleted() {}
+                }
+
+            val requestObserver = stub.publishBuildToolEventStream(responseObserver)
+
+            val request =
+                PublishBuildToolEventStreamRequest
+                    .newBuilder()
+                    .setOrderedBuildEvent(
+                        OrderedBuildEvent
+                            .newBuilder()
+                            .setSequenceNumber(1)
+                            .setStreamId(streamId)
+                            .setEvent(largeEvent)
+                            .build(),
+                    ).build()
+
+            requestObserver.onNext(request)
+            requestObserver.onCompleted()
+
+            // Wait for the event to be received
+            Assert.assertTrue(
+                eventLatch.await(1, TimeUnit.SECONDS),
+                "Should receive the large message within timeout",
+            )
+
+            // Verify the event was received
+            Assert.assertEquals(receivedEvents.size, 1, "Should receive exactly one event")
+            Assert.assertEquals(
+                receivedEvents[0].bazelEvent.value.size(),
+                largeData.size(),
+                "Received event should have the same size as sent",
+            )
+
+            // Verify response was sent
+            Assert.assertTrue(
+                responseLatch.await(1, TimeUnit.SECONDS),
+                "Should receive response within timeout",
+            )
+        } finally {
+            channel.shutdown()
+            channel.awaitTermination(1, TimeUnit.SECONDS)
+        }
+    }
+
+    @Test
+    fun testDefaultMessageSizeLimit() {
+        // This test verifies that without our fix, messages over 4MB would fail
+        // Since we've already applied the fix, this test will pass
+        // In a real scenario, you might want to parameterize the max message size
+
+        val service =
+            BesGrpcServerEventStream(messageWriter) { result ->
+                when (result) {
+                    is BesGrpcServerEventStream.Result.Event -> {
+                        // Event received successfully
+                    }
+                    is BesGrpcServerEventStream.Result.Error -> {
+                        Assert.fail("Should handle large messages without error")
+                    }
+                }
+            }
+
+        serverCloseable = grpcServer.start(service)
+        val actualPort = grpcServer.port
+
+        // Just verify the server started successfully with our configuration
+        Assert.assertTrue(actualPort > 0, "Server should start successfully")
+
+        // In production, you might want to make the max message size configurable
+        // and test different size limits
+    }
+
+    @Test
+    fun testConfigurableMessageSizeLimit() {
+        // Test with a smaller message size limit
+        val smallLimitServer = GrpcServer(messageWriter, port, _maxMessageSizeMb = 2) // 2MB limit
+        val errorLatch = CountDownLatch(1)
+
+        val service =
+            BesGrpcServerEventStream(messageWriter) { result ->
+                when (result) {
+                    is BesGrpcServerEventStream.Result.Event -> {
+                        // Should not receive this event as it exceeds the limit
+                        Assert.fail("Should not receive event exceeding size limit")
+                    }
+                    is BesGrpcServerEventStream.Result.Error -> {
+                        // Expected - message too large
+                        errorLatch.countDown()
+                    }
+                }
+            }
+
+        val closeable = smallLimitServer.start(service)
+        try {
+            val actualPort = smallLimitServer.port
+            Assert.assertTrue(actualPort > 0, "Server should be started on a valid port")
+
+            // Create a client channel with matching size limit
+            val channel =
+                ManagedChannelBuilder
+                    .forAddress("localhost", actualPort)
+                    .usePlaintext()
+                    .maxInboundMessageSize(2 * 1024 * 1024) // Match server's 2MB limit
+                    .build()
+
+            try {
+                val stub = PublishBuildEventGrpc.newStub(channel)
+
+                // Create a message larger than 2MB but smaller than default
+                val largeData = ByteString.copyFrom(ByteArray(3 * 1024 * 1024)) // 3MB of data
+                val largeEvent =
+                    BuildEvent
+                        .newBuilder()
+                        .setBazelEvent(
+                            Any
+                                .newBuilder()
+                                .setTypeUrl("type.googleapis.com/test.LargeEvent")
+                                .setValue(largeData)
+                                .build(),
+                        ).build()
+
+                val streamId =
+                    StreamId
+                        .newBuilder()
+                        .setBuildId("test-build-id")
+                        .build()
+
+                // Send the large message
+                val clientErrorLatch = CountDownLatch(1)
+                val responseObserver =
+                    object : StreamObserver<PublishBuildToolEventStreamResponse> {
+                        override fun onNext(value: PublishBuildToolEventStreamResponse) {}
+
+                        override fun onError(t: Throwable) {
+                            clientErrorLatch.countDown()
+                        }
+
+                        override fun onCompleted() {}
+                    }
+
+                val requestObserver = stub.publishBuildToolEventStream(responseObserver)
+
+                val request =
+                    PublishBuildToolEventStreamRequest
+                        .newBuilder()
+                        .setOrderedBuildEvent(
+                            OrderedBuildEvent
+                                .newBuilder()
+                                .setSequenceNumber(1)
+                                .setStreamId(streamId)
+                                .setEvent(largeEvent)
+                                .build(),
+                        ).build()
+
+                requestObserver.onNext(request)
+                requestObserver.onCompleted()
+
+                // Wait for the error to be received
+                Assert.assertTrue(
+                    clientErrorLatch.await(1, TimeUnit.SECONDS),
+                    "Should receive error for oversized message",
+                )
+            } finally {
+                channel.shutdown()
+                channel.awaitTermination(1, TimeUnit.SECONDS)
+            }
+        } finally {
+            closeable.close()
+        }
+    }
+}


### PR DESCRIPTION
Fix the issue #58.