### PR TITLE
Fix BEP binary reader getting permanently stuck on unreadable events

### DIFF
--- a/plugin-bazel-event-service/src/main/kotlin/bazel/BinaryFileEventStream.kt
+++ b/plugin-bazel-event-service/src/main/kotlin/bazel/BinaryFileEventStream.kt
@@ -2,6 +2,7 @@ package bazel
 
 import bazel.messages.MessageWriter
 import com.google.devtools.build.lib.buildeventstream.BuildEventStreamProtos
+import com.google.protobuf.CodedInputStream
 import com.google.protobuf.InvalidProtocolBufferException
 import java.nio.channels.Channels
 import java.nio.channels.FileChannel
@@ -40,6 +41,8 @@ class BinaryFileEventStream(
     ) {
         private val disposed = AtomicBoolean()
         private var sequenceNumber: Long = 0
+        private var lastFailedPosition: Long = -1
+        private var failedAtSamePositionCount: Int = 0
 
         fun start(onEvent: (Result) -> Unit): AutoCloseable {
             val thread = thread(name = "BazelEventStream") { readBazelStreamLoop(onEvent) }
@@ -100,8 +103,28 @@ class BinaryFileEventStream(
                         channel.position(positionBeforeRead)
                         return
                     }
+                    lastFailedPosition = -1
+                    failedAtSamePositionCount = 0
                     onEvent(Result.Event(sequenceNumber++, evt))
                 } catch (ex: Exception) {
+                    if (positionBeforeRead == lastFailedPosition) {
+                        failedAtSamePositionCount++
+                    } else {
+                        lastFailedPosition = positionBeforeRead
+                        failedAtSamePositionCount = 1
+                    }
+
+                    if (failedAtSamePositionCount > MAX_RETRIES_AT_SAME_POSITION &&
+                        ex is InvalidProtocolBufferException
+                    ) {
+                        messageWriter.warning(
+                            "Skipping unreadable bazel event at position $positionBeforeRead " +
+                                "after $MAX_RETRIES_AT_SAME_POSITION retries"
+                        )
+                        skipMessage(channel, positionBeforeRead)
+                        continue
+                    }
+
                     if (ex is InvalidProtocolBufferException) {
                         messageWriter.trace("Attempt to read truncated bazel event message at position $positionBeforeRead")
                     } else {
@@ -113,6 +136,31 @@ class BinaryFileEventStream(
                     return
                 }
             }
+        }
+
+        private fun skipMessage(channel: FileChannel, position: Long) {
+            try {
+                channel.position(position)
+                val input = Channels.newInputStream(channel)
+                val codedInput = CodedInputStream.newInstance(input)
+                val messageSize = codedInput.readRawVarint32()
+                val newPosition = channel.position() + messageSize
+                if (newPosition <= channel.size()) {
+                    channel.position(newPosition)
+                    messageWriter.trace("Skipped $messageSize bytes, now at position ${channel.position()}")
+                } else {
+                    channel.position(position)
+                }
+            } catch (ex: Exception) {
+                messageWriter.trace("Could not skip message at $position: ${ex.message}")
+                channel.position(position + 1)
+            }
+            lastFailedPosition = -1
+            failedAtSamePositionCount = 0
+        }
+
+        companion object {
+            private const val MAX_RETRIES_AT_SAME_POSITION = 10
         }
     }
 }


### PR DESCRIPTION
## Problem

`BinaryFileEventStream.readBazelEvents()` gets permanently stuck when it encounters a protobuf message that cannot be parsed. The reader resets to the same file position and returns. On the next poll cycle (200ms), it reads from the same position and hits the same `InvalidProtocolBufferException` — repeating infinitely for the rest of the build.

This causes all subsequent BEP events to be missed, including `test_result` events that contain the `test.xml` path. Without `test_result`, no `##teamcity[importData type='junit' ...]` service message is emitted, and **TeamCity reports 0 test occurrences** despite tests passing.

## Observed symptoms

**Build:** [ijplatform_staging_BazelPluginIdeStarterTest_Simple_Java_combined_test #1](https://buildserver.labs.intellij.net/buildConfiguration/ijplatform_staging_BazelPluginIdeStarterTest_Simple_Java_combined_test/876920824)

- Build status: SUCCESS
- Tests tab: **0 tests** (should be 3)
- `test.xml` artifact: present and valid (3 testcases, all passed)
- `test.log`: shows all 3 tests passed via Bazel stdout

**Compared with:** [SimpleKotlinCombinedTest #1](https://buildserver.labs.intellij.net/buildConfiguration/ijplatform_staging_BazelPluginIdeStarterTest_Simple_Kotlin_combined_test/876920823) — 5 tests correctly reported

### Build log evidence

The reader gets stuck at position 1359872 and retries **4,825 times** over ~16 minutes:

```
[06:28:42] Unknown event: id { progress { opaque_count: 2014 } } children { fetch { url: "..." } }
[06:28:43] Attempt to read truncated bazel event message at position 1359872
[06:28:44] Attempt to read truncated bazel event message at position 1359872
[06:28:45] Attempt to read truncated bazel event message at position 1359872
... (4,825 retries until build ends at 06:44)
```

The Java combined test triggers many BEP `fetch` events (inner Bazel builds for bytecode compilation) which likely produce a BEP message that cannot be parsed by the current protobuf version. The reader never advances past this message, so the `test_result` event (written after the test completes) is never reached.

The Kotlin combined test (which has no inner Bazel builds and thus no `fetch` events) processes all BEP events correctly — including `test_result` → `importData` → 5 test occurrences.

## Fix

Track consecutive parse failures at the same file position. After 10 retries at the same offset, skip the malformed message by reading its varint length prefix and advancing past it. This allows the reader to recover and continue processing subsequent events.

## Test plan

- [ ] Verify the fix with a BEP binary file containing a malformed message followed by valid events
- [ ] Verify normal operation is not affected (temporarily truncated messages still retry correctly)
- [ ] Run against the failing build configuration to confirm test results are now reported