### PR TITLE
TestResultHandler breaks stdout/stderr content of JUnit XML test reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- TestResultHandler breaks stdout/stderr content of JUnit XML test reports
+
 ## 0.2.1 - 2026-03-16
 
 ### Fixed

--- a/plugin-bazel-event-service/src/main/kotlin/bazel/handlers/build/TestResultHandler.kt
+++ b/plugin-bazel-event-service/src/main/kotlin/bazel/handlers/build/TestResultHandler.kt
@@ -13,7 +13,6 @@ import bazel.messages.apply
 import bazel.messages.toColor
 import java.io.FileNotFoundException
 import java.io.InputStreamReader
-import java.io.OutputStreamWriter
 import java.time.Duration
 
 class TestResultHandler(
@@ -88,10 +87,9 @@ class TestResultHandler(
         isRemoteCacheHit: Boolean,
     ) {
         try {
-            val content = readFileLines(ctx, test)
             when {
-                test.name.endsWith(".xml") -> importXmlTestResults(ctx, test.name, content)
-                test.name.endsWith(".log") -> printLogTestResults(ctx, content)
+                test.name.endsWith(".xml") -> importXmlTestResults(ctx, test)
+                test.name.endsWith(".log") -> printLogTestResults(ctx, readFileLines(ctx, test))
             }
         } catch (ex: Exception) {
             if (isRemoteCacheHit && ex is FileNotFoundException) {
@@ -109,14 +107,15 @@ class TestResultHandler(
 
     private fun importXmlTestResults(
         ctx: BuildEventHandlerContext,
-        fileName: String,
-        content: List<String>,
+        test: File,
     ) {
-        val testTempFile = _fileSystemService.generateTempFile("tmp", fileName)
-        _fileSystemService.write(testTempFile) { stream ->
-            OutputStreamWriter(stream).use { writer -> content.forEach { writer.write(it) } }
+        test.createStream().use { input ->
+            val testTempFile = _fileSystemService.generateTempFile("tmp", test.name)
+            _fileSystemService.write(testTempFile) { stream ->
+                input.copyTo(stream)
+            }
+            ctx.writer.importJUnitReport(testTempFile.absolutePath)
         }
-        ctx.writer.importJUnitReport(testTempFile.absolutePath)
     }
 
     private fun printLogTestResults(

--- a/plugin-bazel-event-service/src/test/kotlin/bazel/tests/TestResultHandlerTest.kt
+++ b/plugin-bazel-event-service/src/test/kotlin/bazel/tests/TestResultHandlerTest.kt
@@ -18,6 +18,7 @@ import org.testng.Assert
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.DataProvider
 import org.testng.annotations.Test
+import java.nio.file.Files
 import kotlin.io.path.Path
 
 class TestResultHandlerTest {
@@ -64,6 +65,51 @@ class TestResultHandlerTest {
             Assert.assertTrue(it.all { m -> m.tags.contains("tc:parseServiceMessagesInside") }, content)
             Assert.assertTrue(it.any { m -> m.attributes["text"] == "line 1" }, content)
             Assert.assertTrue(it.any { m -> m.attributes["text"] == "##teamcity[line 2]" }, content)
+        }
+    }
+
+    @Test
+    fun `should preserve test report bytes when importing xml`() {
+        // arrange
+        val handler = TestResultHandler(FileSystemService())
+        val reportContent =
+            (
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+                    "<testsuite>\n" +
+                    "  <testcase name=\"should preserve line endings\">\r\n" +
+                    "    <system-out>line 1&#10;line 2</system-out>\n" +
+                    "  </testcase>\r\n" +
+                    "</testsuite>\n"
+            ).toByteArray(Charsets.UTF_8)
+        val bazelEvent =
+            buildEvent {
+                testResult =
+                    testResult {
+                        addTestActionOutput(
+                            file {
+                                name = "test.xml"
+                                contents = ByteString.copyFrom(reportContent)
+                            },
+                        )
+                    }
+            }
+
+        val serviceMessages = mutableListOf<ServiceMessage>()
+        val ctx = createContext(bazelEvent, Verbosity.Normal, serviceMessages)
+
+        // act
+        handler.handle(ctx)
+
+        // assert
+        val importedPath = serviceMessages.single().attributes["path"]!!
+        try {
+            val importedContent = Files.readAllBytes(Path(importedPath))
+            Assert.assertTrue(
+                importedContent.contentEquals(reportContent),
+                "Imported XML content must match the original bytes.",
+            )
+        } finally {
+            Files.deleteIfExists(Path(importedPath))
         }
     }
 


### PR DESCRIPTION
## Summary

Previously XML reports were read with `readLines()` and written back line-by-line, which removed or altered line separators. Now XML report streams are copied directly into the temporary import file, preserving original line endings and content.

## Changes

- Copy JUnit XML report content byte-for-byte using stream copying.
- Keep `.log` handling unchanged, still reading logs line-by-line for TeamCity service messages.
- Add a regression test that verifies imported XML bytes match the original content, including mixed `CRLF`/`LF` line endings.

