### PR TITLE
Support custom targets for bazel fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Support for the `fetch` command — targets are now passed to `bazel fetch` instead of being dropped by the custom-command fallback
+
 ### Changed
 
 ### Fixed

--- a/plugin-bazel-agent/src/main/kotlin/jetbrains/buildServer/bazel/commands/FetchCommand.kt
+++ b/plugin-bazel-agent/src/main/kotlin/jetbrains/buildServer/bazel/commands/FetchCommand.kt
@@ -1,0 +1,23 @@
+
+
+package jetbrains.buildServer.bazel.commands
+
+import jetbrains.buildServer.bazel.*
+
+/**
+ * Provides arguments to bazel fetch command.
+ */
+class FetchCommand(
+    private val _commonArgumentsProvider: CommonArgumentsProvider,
+    private val _targetsArgumentsProvider: TargetsArgumentsProvider,
+) : BazelCommand {
+    override val command: String = BazelConstants.COMMAND_FETCH
+
+    override val arguments: Sequence<CommandArgument>
+        get() =
+            sequence {
+                yield(CommandArgument(CommandArgumentType.Command, command))
+                yieldAll(_commonArgumentsProvider.getArguments(this@FetchCommand))
+                yieldAll(_targetsArgumentsProvider.getArguments(this@FetchCommand))
+            }
+}

--- a/plugin-bazel-agent/src/main/resources/META-INF/build-agent-plugin-bazel.xml
+++ b/plugin-bazel-agent/src/main/resources/META-INF/build-agent-plugin-bazel.xml
@@ -47,6 +47,7 @@
     <!--bazel commands-->
     <bean class="jetbrains.buildServer.bazel.commands.BuildCommand"/>
     <bean class="jetbrains.buildServer.bazel.commands.CleanCommand"/>
+    <bean class="jetbrains.buildServer.bazel.commands.FetchCommand"/>
     <bean class="jetbrains.buildServer.bazel.commands.RunCommand"/>
     <bean class="jetbrains.buildServer.bazel.commands.TestCommand"/>
     <bean class="jetbrains.buildServer.bazel.commands.ShutdownCommand"/>

--- a/plugin-bazel-common/src/main/kotlin/jetbrains/buildServer/bazel/BazelConstants.kt
+++ b/plugin-bazel-common/src/main/kotlin/jetbrains/buildServer/bazel/BazelConstants.kt
@@ -19,6 +19,7 @@ object BazelConstants {
 
     const val COMMAND_BUILD = "build"
     const val COMMAND_CLEAN = "clean"
+    const val COMMAND_FETCH = "fetch"
     const val COMMAND_RUN = "run"
     const val COMMAND_TEST = "test"
     const val COMMAND_SHUTDOWN = "shutdown"

--- a/plugin-bazel-server/src/main/kotlin/jetbrains/buildServer/bazel/fetchers/BazelCommandFetcher.kt
+++ b/plugin-bazel-server/src/main/kotlin/jetbrains/buildServer/bazel/fetchers/BazelCommandFetcher.kt
@@ -23,6 +23,7 @@ class BazelCommandFetcher : ProjectDataFetcher {
             listOf(
                 BazelConstants.COMMAND_BUILD,
                 BazelConstants.COMMAND_CLEAN,
+                BazelConstants.COMMAND_FETCH,
                 BazelConstants.COMMAND_RUN,
                 BazelConstants.COMMAND_TEST,
             ).map {


### PR DESCRIPTION
Without this fix, it skips the targets and fetches everything