### PR TITLE
Stream test.log instead of buffering it to avoid event-service OOM

### DIFF
--- a/plugin-bazel-event-service/src/main/kotlin/bazel/handlers/build/TestResultHandler.kt
+++ b/plugin-bazel-event-service/src/main/kotlin/bazel/handlers/build/TestResultHandler.kt
@@ -89,7 +89,7 @@ class TestResultHandler(
         try {
             when {
                 test.name.endsWith(".xml") -> importXmlTestResults(ctx, test)
-                test.name.endsWith(".log") -> printLogTestResults(ctx, readFileLines(ctx, test))
+                test.name.endsWith(".log") -> streamLogTestResults(ctx, test)
             }
         } catch (ex: Exception) {
             if (isRemoteCacheHit && ex is FileNotFoundException) {
@@ -118,24 +118,23 @@ class TestResultHandler(
         }
     }
 
-    private fun printLogTestResults(
-        ctx: BuildEventHandlerContext,
-        content: List<String>,
-    ) {
-        // print log file as a message
-        // tc:parseServiceMessagesInside will parse teamcity service messages if it has any
-        content.forEach { ctx.writer.message(it) }
-    }
-
-    private fun readFileLines(
+    // A test.log holds the combined stdout/stderr of the whole test action, so it can reach tens of GB
+    // (e.g. a hanging test with --test_output=streamed). Do not materialize it.
+    private fun streamLogTestResults(
         ctx: BuildEventHandlerContext,
         file: File,
-    ): List<String> {
-        val content = InputStreamReader(file.createStream()).use { it.readLines() }
-        if (ctx.verbosity.atLeast(Verbosity.Diagnostic)) {
+    ) {
+        val diagnostic = ctx.verbosity.atLeast(Verbosity.Diagnostic)
+        if (diagnostic) {
             ctx.writer.trace("File \"$file\":")
-            content.forEach { ctx.writer.trace("$\t$it") }
         }
-        return content
+
+        // tc:parseServiceMessagesInside will parse teamcity service messages if the line has any
+        InputStreamReader(file.createStream()).forEachLine { line ->
+            ctx.writer.message(line)
+            if (diagnostic) {
+                ctx.writer.trace("$\t$line")
+            }
+        }
     }
 }


### PR DESCRIPTION
Whole build configuration fails with OOM due to this:
https://buildserver.labs.intellij.net/buildConfiguration/ijplatform_master_Toolbox_IntegrationTestOnLinuxShard_3

```
Exception in thread "BazelEventStream" java.lang.OutOfMemoryError: Java heap space
      at kotlin.io.TextStreamsKt.readLines(ReadWrite.kt:44)
      at bazel.handlers.build.TestResultHandler.readFileLines(TestResultHandler.kt:134)
      at bazel.handlers.build.TestResultHandler.readTestResults(TestResultHandler.kt:92)
      at bazel.handlers.build.TestResultHandler.handle(TestResultHandler.kt:73)
      at bazel.BinaryFileEventStream$Listener.readBazelStreamLoop(BinaryFileEventStream.kt:68)
```


TestResultHandler read the whole test.log into a List<String> via   readLines() before emitting it. A test.log holds the combined  stdout/stderr of the entire test action, so it can get pretty big.
  